### PR TITLE
Fix #21 issue with Windows setup

### DIFF
--- a/discretization.py
+++ b/discretization.py
@@ -115,7 +115,7 @@ class MDLP(BaseEstimator, TransformerMixin):
 
         X = check_array(X, force_all_finite=True, ensure_2d=False)
         y = column_or_1d(y)
-        y = check_array(y, ensure_2d=False, dtype=int)
+        y = check_array(y, ensure_2d=False, dtype=np.int64)
         X, y = check_X_y(X, y)
 
         if not self.shuffle:


### PR DESCRIPTION
Windows users have reported the following error on their system when installing this package:

```
File "C:\Users\es036b\AppData\Local\Continuum\Anaconda3\lib\site-packages\sklearn\base.py", line 458, in fit_transform
return self.fit(X, y, **fit_params).transform(X)

File "C:\Users\es036b\Documents\Code\mdlp-discretization-master\discretization.py", line 142, in fit
cut_points = MDLPDiscretize(col, y, self.min_depth)

File "_mdlp.pyx", line 40, in _mdlp.MDLPDiscretize (_mdlp.cpp:1942)
k = find_cut(y, start, end)

File "_mdlp.pyx", line 106, in _mdlp.find_cut (_mdlp.cpp:3412)
def find_cut(np.ndarray[np.int64_t, ndim=1] y, int start, int end):

ValueError: Buffer dtype mismatch, expected 'int64_t' but got 'long'
```

This PR resolves the issue reported in #21.