### PR TITLE
Sparse matrices and parallel fit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
 
     setup(
         name='mdlp-discretization',
-        version='0.3',
+        version='0.4',
         description=__doc__,
         license='BSD 3 Clause',
         url='github.com/hlin117/mdlp-discretization',

--- a/tests/test_mdlp.py
+++ b/tests/test_mdlp.py
@@ -131,3 +131,21 @@ def test_drop_collapsed_features_sparse():
     y = np.array([0, 0, 1, 2])
     disc = MDLP(drop_collapsed_features=True, shuffle=False).fit_transform(X, y)
     assert_array_equal(expected, disc.toarray())
+
+def test_multiprocessing():
+    expected = [
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 1, 0, 1, 0],
+        [0, 2, 0, 2, 0],
+    ]
+
+    X = np.array([
+        [0.1, 0.1, 0.1, 0.1, 0.1],
+        [0.4, 0.2, 0.4, 0.2, 0.4],
+        [0.2, 0.3, 0.2, 0.3, 0.2],
+        [0.3, 0.4, 0.3, 0.4, 0.3]
+    ])
+    y = np.array([0, 0, 1, 2])
+    disc = MDLP(n_jobs=3, shuffle=False).fit_transform(X, y)
+    assert_array_equal(expected, disc)

--- a/tests/test_mdlp.py
+++ b/tests/test_mdlp.py
@@ -133,6 +133,9 @@ def test_drop_collapsed_features_sparse():
     assert_array_equal(expected, disc.toarray())
 
 def test_multiprocessing():
+    """Only tests that the functionality is not affected, not that parallel
+       processing actually takes place.
+    """
     expected = [
         [0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0],

--- a/tests/test_mdlp.py
+++ b/tests/test_mdlp.py
@@ -1,5 +1,6 @@
 import itertools
 import numpy as np
+import scipy.sparse
 
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_almost_equal
@@ -32,45 +33,64 @@ def test_find_cut_no_cut():
     assert_equal(-1, k)
 
 def test_fit_transform_scale():
-  expected = [
-    [0, 0],
-    [0, 0],
-    [1, 0],
-    [2, 0],
-  ]
+    expected = [
+        [0, 0],
+        [0, 0],
+        [1, 0],
+        [2, 0],
+    ]
 
-  X = np.array([
-    [0.1, 0.1],
-    [0.2, 0.4],
-    [0.3, 0.2],
-    [0.4, 0.3]
-  ])
-  y = np.array([0, 0, 1, 2])
-  for i in range(10):
-    scaled_disc = MDLP(shuffle=False).fit_transform(X / 10**i, y)
-    assert_array_equal(expected, scaled_disc)
+    X = np.array([
+        [0.1, 0.1],
+        [0.2, 0.4],
+        [0.3, 0.2],
+        [0.4, 0.3]
+    ])
+    y = np.array([0, 0, 1, 2])
+    for i in range(10):
+        scaled_disc = MDLP(shuffle=False).fit_transform(X / 10**i, y)
+        assert_array_equal(expected, scaled_disc)
 
 def test_fit_transform_translate():
-  expected = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1]).reshape(-1, 1)
+    expected = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1]).reshape(-1, 1)
 
-  X = np.arange(9, dtype=float).reshape(-1, 1)
-  y = np.array([0, 0, 0, 0, 1, 0, 1, 1, 1])
-  transformed = MDLP(shuffle=False).fit_transform(X, y)
-  assert_array_equal(expected, transformed)
+    X = np.arange(9, dtype=float).reshape(-1, 1)
+    y = np.array([0, 0, 0, 0, 1, 0, 1, 1, 1])
+    transformed = MDLP(shuffle=False).fit_transform(X, y)
+    assert_array_equal(expected, transformed)
 
-  # translating data does not affect discretization result
-  translated = MDLP(shuffle=False).fit_transform(X - 5, y)
-  assert_array_equal(expected, translated)
+    # translating data does not affect discretization result
+    translated = MDLP(shuffle=False).fit_transform(X - 5, y)
+    assert_array_equal(expected, translated)
 
 def test_coerce_list():
-  expected = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1]).reshape(-1, 1)
+    expected = np.array([0, 0, 0, 0, 1, 1, 1, 1, 1]).reshape(-1, 1)
 
-  X = [[i] for i in range(9)]
-  y = [0, 0, 0, 0, 1, 0, 1, 1, 1]
-  transformed = MDLP(shuffle=False).fit_transform(X, y)
-  assert_array_equal(expected, transformed)
+    X = [[i] for i in range(9)]
+    y = [0, 0, 0, 0, 1, 0, 1, 1, 1]
+    transformed = MDLP(shuffle=False).fit_transform(X, y)
+    assert_array_equal(expected, transformed)
 
-  np_X = np.arange(9).reshape(-1, 1)
-  np_y = np.array([0, 0, 0, 0, 1, 0, 1, 1, 1])
-  np_transformed = MDLP(shuffle=False).fit_transform(np_X, np_y)
-  assert_array_equal(expected, np_transformed)
+    np_X = np.arange(9).reshape(-1, 1)
+    np_y = np.array([0, 0, 0, 0, 1, 0, 1, 1, 1])
+    np_transformed = MDLP(shuffle=False).fit_transform(np_X, np_y)
+    assert_array_equal(expected, np_transformed)
+
+def test_csr_input():
+    expected = [
+        [0, 0],
+        [0, 0],
+        [1, 0],
+        [2, 0],
+    ]
+
+    dense_X = np.array([
+        [0.1, 0.1],
+        [0.2, 0.4],
+        [0.3, 0.2],
+        [0.4, 0.3]
+    ])
+    X = scipy.sparse.csr_matrix(dense_X)
+    y = np.array([0, 0, 1, 2])
+    disc = MDLP(shuffle=False).fit_transform(X, y)
+    assert_array_equal(expected, disc.toarray())

--- a/tests/test_mdlp.py
+++ b/tests/test_mdlp.py
@@ -76,7 +76,25 @@ def test_coerce_list():
     np_transformed = MDLP(shuffle=False).fit_transform(np_X, np_y)
     assert_array_equal(expected, np_transformed)
 
-def test_csr_input():
+def test_drop_collapsed_features_dense():
+    expected = [
+        [0, 0],
+        [0, 0],
+        [1, 1],
+        [2, 2],
+    ]
+
+    X = np.array([
+        [0.1, 0.1, 0.1, 0.1, 0.1],
+        [0.4, 0.2, 0.4, 0.2, 0.4],
+        [0.2, 0.3, 0.2, 0.3, 0.2],
+        [0.3, 0.4, 0.3, 0.4, 0.3]
+    ])
+    y = np.array([0, 0, 1, 2])
+    disc = MDLP(drop_collapsed_features=True, shuffle=False).fit_transform(X, y)
+    assert_array_equal(expected, disc)
+
+def test_sparse_input():
     expected = [
         [0, 0],
         [0, 0],
@@ -93,4 +111,23 @@ def test_csr_input():
     X = scipy.sparse.csr_matrix(dense_X)
     y = np.array([0, 0, 1, 2])
     disc = MDLP(shuffle=False).fit_transform(X, y)
+    assert_array_equal(expected, disc.toarray())
+
+def test_drop_collapsed_features_sparse():
+    expected = [
+        [0, 0],
+        [0, 0],
+        [1, 1],
+        [2, 2],
+    ]
+
+    dense_X = np.array([
+        [0.1, 0.1, 0.1, 0.1, 0.1],
+        [0.4, 0.2, 0.4, 0.2, 0.4],
+        [0.2, 0.3, 0.2, 0.3, 0.2],
+        [0.3, 0.4, 0.3, 0.4, 0.3]
+    ])
+    X = scipy.sparse.csr_matrix(dense_X)
+    y = np.array([0, 0, 1, 2])
+    disc = MDLP(drop_collapsed_features=True, shuffle=False).fit_transform(X, y)
     assert_array_equal(expected, disc.toarray())


### PR DESCRIPTION
I have made a few changes for my own use that I think others might benefit from, hence this pull request. The new features are:

* support for sparse matrices, which are common in NLP tasks; previously the transformation would just fail if supplied with a sparse matrix, now it should process it
* removal of features that ended up with a single bucket only; this again speeds up processing and reduces memory pressure in very high-dimensional problems
* parallel `fit`, with the customary `n_jobs` parameter controlling the degree of parallelism. The `transform` has not been parallelised yet, but since it is orders of magnitude faster that is not very important in my opinion.

All of those only required changes in the Python wrapper, not in the native part. They should be fully backwards-compatible.

If you would prefer only some of those features but not the others then I will be happy to split this PR up. I also appreciate that they might not fit with your concept of how the library should evolve; if so, no problem at all, I will just use my fork.
